### PR TITLE
enhancement: changeable image pull policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Whether to create the namespace | `bool` | `true` | no |
+| <a name="input_image_pull_policy"></a> [image\_pull\_policy](#input\_image\_pull\_policy) | Defines the image pull policy to use. | `string` | `"Always"` | no |
 | <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | The image repository to use | `string` | `"docker.fylr.io/services/postfix"` | no |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | Defines the image version to use. | `string` | `"v1.0.0"` | no |
 | <a name="input_mail_email"></a> [mail\_email](#input\_mail\_email) | n/a | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "kubernetes_deployment_v1" "postfix" {
         container {
           image = "${var.image_repository}:${var.image_version}"
           name  = "postfix-${var.name}"
+          image_pull_policy = var.image_pull_policy
 
           resources {
             limits = {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,16 @@ variable "image_version" {
   sensitive   = false
 }
 
+variable "image_pull_policy" {
+  type        = string
+  description = "Defines the image pull policy to use."
+  default     = "IfNotPresent"
+  validation {
+    condition     = var.image_pull_policy == "Always" || var.image_pull_policy == "IfNotPresent" || var.image_pull_policy == "Never"
+    error_message = "Invalid image pull policy. Valid values are `Always`, `IfNotPresent` and `Never`."
+  }
+}
+
 variable "resources" {
   type = object({
     limits = object({
@@ -90,10 +100,10 @@ variable "postfix_mynetworks" {
 }
 
 variable "postfix_smtputf8_enable" {
-  type      = string
-  default   = "no"
+  type        = string
+  default     = "no"
   description = "Can be 'yes' or 'no'."
-  sensitive = false
+  sensitive   = false
 }
 
 variable "postfix_smtp_sasl_auth_enable" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "image_version" {
 variable "image_pull_policy" {
   type        = string
   description = "Defines the image pull policy to use."
-  default     = "IfNotPresent"
+  default     = "Always"
   validation {
     condition     = var.image_pull_policy == "Always" || var.image_pull_policy == "IfNotPresent" || var.image_pull_policy == "Never"
     error_message = "Invalid image pull policy. Valid values are `Always`, `IfNotPresent` and `Never`."


### PR DESCRIPTION
This PR adds an option to change the behavior when pulling containers into Kubernetes. Before this change was introduced, the image_pull_policy was automatically set to `IfNotPresent`.