### PR TITLE
fix: deployment component order

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -21,7 +21,7 @@ module "postfix" {
   postfix_relayhost                    = "smtp.gmail.com:587"
   postfix_myhostname                   = "mail"
   postfix_mynetworks                   = "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
-  postfix_smtputf8_enable              = "on"
+  postfix_smtputf8_enable              = "yes"
   postfix_smtp_sasl_auth_enable        = "yes"
   postfix_smtp_sasl_password_maps      = "hash:/etc/postfix/sasl_passwd"
   postfix_smtp_sasl_security_options   = ""

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,10 @@ resource "kubernetes_namespace_v1" "postfix" {
 }
 
 resource "kubernetes_secret_v1" "sasl-config" {
+  depends_on = [
+    kubernetes_namespace_v1.postfix,
+  ]
+
   metadata {
     name      = "postgres-${var.name}-sasl-config"
     namespace = var.namespace
@@ -35,6 +39,10 @@ resource "kubernetes_secret_v1" "sasl-config" {
 
 # postfix deployment
 resource "kubernetes_deployment_v1" "postfix" {
+  depends_on = [
+    kubernetes_namespace_v1.postfix,
+  ]
+
   wait_for_rollout = var.wait_for_rollout
 
   metadata {
@@ -167,6 +175,10 @@ resource "kubernetes_deployment_v1" "postfix" {
 }
 
 resource "kubernetes_service_v1" "postfix-service" {
+  depends_on = [
+    kubernetes_namespace_v1.postfix,
+  ]
+
   metadata {
     name      = "postfix-${var.name}"
     namespace = var.namespace


### PR DESCRIPTION
In previous deployments, it sometimes happened that a component was created before the actual namespace existed. Because the resource had the namespace defined by reference, Kubernetes returned an error message that caused the deployment to fail.